### PR TITLE
Add mirror link for all instructions booklets

### DIFF
--- a/sets/10281/10281_EN_Info_Booklet.pdf
+++ b/sets/10281/10281_EN_Info_Booklet.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7fe7d996a44c015e7021a3906e913552b0a31aab2e02bd88943fdaa34c61255f
-size 3106906

--- a/sets/10281/10281_IT_Info_Booklet.pdf
+++ b/sets/10281/10281_IT_Info_Booklet.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e61e2e27d063b40edf1c5c111a9b794ee972be6cfbb6b088726bad3641aee9e7
-size 3108438

--- a/sets/10281/6392350.pdf
+++ b/sets/10281/6392350.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed556e10eb95c29da914f99f887fed7c6c052ff319316b834883ad7b36874438
-size 17808220

--- a/sets/10281/README.md
+++ b/sets/10281/README.md
@@ -1,2 +1,26 @@
 # 10281 Bonsai Tree
 
+![box-image](https://img.bricklink.com/ItemImage/ON/0/10281-1.png)
+
+|              |       | 
+|  ---:        | ---   |
+|Year Released:| 2021  | 
+|Weight:       | 768g |
+|Item Dim.:    |26 x 38 x 7 cm |
+|Nr. parts:    | 878 |
+|Rated:        | 18+  |
+|              |      |
+
+
+![](https://img.bricklink.com/ItemImage/SL/10281-1.png)
+
+## Instructions
+
+[![lego-official](https://www.lego.com/cdn/product-assets/product.bi.core.img/6392350.png)](https://www.lego.com/cdn/product-assets/product.bi.core.pdf/6392350.pdf)
+[mirror](https://alv67-lfs.s3.cubbit.eu/6392350.pdf)
+
+[![lego official](https://www.lego.com/cdn/product-assets/product.bi.additional.info.img/10281_EN_Info_Booklet.png)](https://www.lego.com/cdn/product-assets/product.bi.additional.info.pdf/10281_EN_Info_Booklet.pdf)
+[mirror](https://alv67-lfs.s3.cubbit.eu/10281_EN_Info_Booklet.pdf)
+
+[![lego official](https://www.lego.com/cdn/product-assets/product.bi.additional.info.img/10281_IT_Info_Booklet.png)](https://www.lego.com/cdn/product-assets/product.bi.additional.info.pdf/10281_IT_Info_Booklet.pdf)
+[mirror](https://alv67-lfs.s3.cubbit.eu/10281_IT_Info_Booklet.pdf)

--- a/sets/10281/README.md
+++ b/sets/10281/README.md
@@ -2,9 +2,9 @@
 
 ![box-image](https://img.bricklink.com/ItemImage/ON/0/10281-1.png)
 
-|              |       | 
+|              |       |
 |  ---:        | ---   |
-|Year Released:| 2021  | 
+|Year Released:| 2021  |
 |Weight:       | 768g |
 |Item Dim.:    |26 x 38 x 7 cm |
 |Nr. parts:    | 878 |
@@ -12,7 +12,7 @@
 |              |      |
 
 
-![](https://img.bricklink.com/ItemImage/SL/10281-1.png)
+![model image](https://img.bricklink.com/ItemImage/SL/10281-1.png)
 
 ## Instructions
 

--- a/sets/10311/10311_IT_BI_Build_Translate.pdf
+++ b/sets/10311/10311_IT_BI_Build_Translate.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e9eb0b627b96eba0f7367689e606258cd1f09232ed41da6a387b07043aa1f4e6
-size 18760551

--- a/sets/10311/6415032.pdf
+++ b/sets/10311/6415032.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b321443ddfb534b7a3b14884b5f345f9f5a35f38d3fed4d43a754dd0c6cca28
-size 19098552

--- a/sets/10311/README.md
+++ b/sets/10311/README.md
@@ -15,9 +15,11 @@
 
 ## Instructions
 
-[ ![](https://www.lego.com/cdn/product-assets/product.bi.core.img/6415032.png) ](https://www.lego.com/cdn/product-assets/product.bi.core.pdf/6415032.pdf)
+[ ![lego official](https://www.lego.com/cdn/product-assets/product.bi.core.img/6415032.png) ](https://www.lego.com/cdn/product-assets/product.bi.core.pdf/6415032.pdf)
+[mirror](https://alv67-lfs.s3.cubbit.eu/6415032.pdf)
 
-[ ![](https://www.lego.com/cdn/product-assets/product.bi.additional.main.img/10311_IT_BI_Build_Translate.png) ](https://www.lego.com/cdn/product-assets/product.bi.additional.main.pdf/10311_IT_BI_Build_Translate.pdf)
+[ ![lego official](https://www.lego.com/cdn/product-assets/product.bi.additional.main.img/10311_IT_BI_Build_Translate.png) ](https://www.lego.com/cdn/product-assets/product.bi.additional.main.pdf/10311_IT_BI_Build_Translate.pdf)
+[mirror](https://alv67-lfs.s3.cubbit.eu/10311_IT_BI_Build_Translate.pdf)
 
 ### The following parts failed to import for 10311-1
 

--- a/sets/10311/README.md
+++ b/sets/10311/README.md
@@ -2,23 +2,23 @@
 
 ![box-image](https://img.bricklink.com/ItemImage/ON/0/10311-1.png)
 
-|              |       | 
+|              |       |
 |  ---:        | ---   |
-|Year Released:| 2022  | 
+|Year Released:| 2022  |
 |Weight:       | 738g |
 |Item Dim.:    |26 x 38 x 7 cm |
 |Nr. parts:    | 608 |
 |Rated:        | 18+  |
 |              |      |
 
-![](https://img.bricklink.com/ItemImage/SL/10311-1.png)
+![model image](https://img.bricklink.com/ItemImage/SL/10311-1.png)
 
 ## Instructions
 
-[ ![lego official](https://www.lego.com/cdn/product-assets/product.bi.core.img/6415032.png) ](https://www.lego.com/cdn/product-assets/product.bi.core.pdf/6415032.pdf)
+[![lego official](https://www.lego.com/cdn/product-assets/product.bi.core.img/6415032.png)](https://www.lego.com/cdn/product-assets/product.bi.core.pdf/6415032.pdf)
 [mirror](https://alv67-lfs.s3.cubbit.eu/6415032.pdf)
 
-[ ![lego official](https://www.lego.com/cdn/product-assets/product.bi.additional.main.img/10311_IT_BI_Build_Translate.png) ](https://www.lego.com/cdn/product-assets/product.bi.additional.main.pdf/10311_IT_BI_Build_Translate.pdf)
+[![lego official](https://www.lego.com/cdn/product-assets/product.bi.additional.main.img/10311_IT_BI_Build_Translate.png)](https://www.lego.com/cdn/product-assets/product.bi.additional.main.pdf/10311_IT_BI_Build_Translate.pdf)
 [mirror](https://alv67-lfs.s3.cubbit.eu/10311_IT_BI_Build_Translate.pdf)
 
 ### The following parts failed to import for 10311-1

--- a/sets/42100/6324712-2.pdf
+++ b/sets/42100/6324712-2.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:020f2436f89df6ca3d2ef2798f91b3021059a7635ff47ddbdfa8abb5517f2611
-size 133168348

--- a/sets/42100/6324712.pdf
+++ b/sets/42100/6324712.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:020f2436f89df6ca3d2ef2798f91b3021059a7635ff47ddbdfa8abb5517f2611
-size 133168348

--- a/sets/42100/README.md
+++ b/sets/42100/README.md
@@ -2,9 +2,9 @@
 
 ![box-image](https://img.bricklink.com/ItemImage/ON/0/42100-1.png)
 
-|              |       | 
+|              |       |
 |  ---:        | ---   |
-|Year Released:| 2019  | 
+|Year Released:| 2019  |
 |Weight:       | 6451g |
 |Item Dim.:    |58.2 x 48 x 17 cm |
 |Nr. parts:    | 4108 |
@@ -12,7 +12,7 @@
 |              |      |
 
 
-![](https://img.bricklink.com/ItemImage/SL/42100-1.png)
+![model image](https://img.bricklink.com/ItemImage/SL/42100-1.png)
 
 ## Instructions
 

--- a/sets/42100/README.md
+++ b/sets/42100/README.md
@@ -16,7 +16,8 @@
 
 ## Instructions
 
-[![](https://www.lego.com/cdn/product-assets/product.bi.core.img/6324096.png)](https://www.lego.com/cdn/product-assets/product.bi.core.pdf/6324096.pdf)
+[![lego-official](https://www.lego.com/cdn/product-assets/product.bi.core.img/6324096.png)](https://www.lego.com/cdn/product-assets/product.bi.core.pdf/6324096.pdf)
+[mirror](https://alv67-lfs.s3.cubbit.eu/6324096.pdf)
 
-[![](https://www.lego.com/cdn/product-assets/product.bi.core.img/6324712.png)](https://www.lego.com/cdn/product-assets/product.bi.core.pdf/6324712.pdf)
-
+[![lego official](https://www.lego.com/cdn/product-assets/product.bi.core.img/6324712.png)](https://www.lego.com/cdn/product-assets/product.bi.core.pdf/6324712.pdf)
+[mirror](https://alv67-lfs.s3.cubbit.eu/6324712.pdf)


### PR DESCRIPTION
Closes #7 
All PDF instructions are now mirrored in Cubbit S3. Eliminate LFS needed.